### PR TITLE
Release 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Semantic Bundle is maintained by [Professional.Wiki]. Contact us for [MediaWiki 
 * **[Semantic Cite](https://www.mediawiki.org/wiki/Extension:Semantic_Cite)** – Allows to manage citation resources using semantic annotations
 * **[Semantic Compound Queries](https://www.mediawiki.org/wiki/Extension:Semantic_Compound_Queries)** – Provides a parser function that displays multiple semantic queries at the same time
 * **[Semantic Extra Special Properties](https://www.mediawiki.org/wiki/Extension:Semantic_Extra_Special_Properties)** – Adds extra special properties to all pages
-* **[Semantic Glossary](https://www.mediawiki.org/wiki/Extension:Semantic_Glossary)** – Allows to define terms as well as abbreviations and manage them with semantic annotations
 * **[Semantic Interlanguage Links](https://www.mediawiki.org/wiki/Extension:Semantic_Interlanguage_Links)** – Allows to create and manage interlanguage links with semantic annotations
 * **[Semantic Meta Tags](https://www.mediawiki.org/wiki/Extension:Semantic_Meta_Tags)** – Allows to extend the meta elements in the HTML header of a page with content generated from semantic annotations
 * **[Semantic Result Formats](https://www.mediawiki.org/wiki/Extension:Semantic_Result_Formats)** – Provides additional formats for semantic queries
@@ -93,6 +92,11 @@ To get the latest set of extensions included by Semantic Bundle, make sure your 
 file contains the latest version of Semantic Bundle.
 
 ## Version history
+
+### Semantic Bundle 4.0.0 (2020-11-02)
+
+* Removed Semantic Glossary
+* Upgraded Maps from ~7.15 to ~7.20
 
 ### Semantic Bundle 3.2.0 (2020-09-13)
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ file contains the latest version of Semantic Bundle.
 ### Semantic Bundle 4.0.0 (2020-11-02)
 
 * Removed Semantic Glossary
-* Upgraded Maps from ~7.15 to ~7.20
 
 ### Semantic Bundle 3.2.0 (2020-09-13)
 

--- a/SemanticBundle.php
+++ b/SemanticBundle.php
@@ -14,7 +14,6 @@ wfLoadExtensions( [
 
 	// Domain specific
 	'SemanticCite',
-	'SemanticGlossary',
 	'SemanticMetaTags',
 	'SemanticBreadcrumbLinks',
 	'SemanticInterlanguageLinks',
@@ -27,7 +26,7 @@ $GLOBALS['wgExtensionCredits']['semantic'][] = [
 	'path' => __FILE__,
 	'namemsg' => 'semantic-bundle-name',
 	'name' => 'AA Semantic Bundle',
-	'version' => '3.2.0',
+	'version' => '4.0.0',
 	'author' => [
 		'[https://www.EntropyWins.wtf/mediawiki Jeroen De Dauw]',
 		'[https://Professional.Wiki/ Professional.Wiki]'

--- a/composer.json
+++ b/composer.json
@@ -47,9 +47,9 @@
 		"mediawiki/semantic-media-wiki": "~3.2.0",
 
 		"mediawiki/semantic-result-formats": "~3.0",
-		"mediawiki/maps": "~7.20",
+		"mediawiki/maps": "^7.20.1",
 		"professional-wiki/modern-timeline": "~1.0",
-		"mediawiki/mermaid": "~2.1.1",
+		"mediawiki/mermaid": "^2.1.1",
 
 		"mediawiki/semantic-extra-special-properties": "~2.0",
 		"mediawiki/semantic-compound-queries": "~2.1",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
 		"mediawiki/semantic-media-wiki": "~3.2.0",
 
 		"mediawiki/semantic-result-formats": "~3.0",
-		"mediawiki/maps": "~7.15",
+		"mediawiki/maps": "~7.20",
 		"professional-wiki/modern-timeline": "~1.0",
 		"mediawiki/mermaid": "~2.1.1",
 
@@ -56,7 +56,6 @@
 
 		"mediawiki/semantic-interlanguage-links": "~2.0",
 		"mediawiki/semantic-cite": "~2.1",
-		"mediawiki/semantic-glossary": "~3.0",
 		"mediawiki/semantic-meta-tags": "~3.0",
 		"mediawiki/semantic-breadcrumb-links": "~2.0",
 


### PR DESCRIPTION
* Remove Semantic Glossary which is incompatible with MediaWiki 1.35+