### PR TITLE
Fix support for composer 2.2.1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,5 +55,10 @@
 		"mediawiki/semantic-compound-queries": "^2.2.0",
 
 		"mediawiki/page-forms": "^5.0.0"
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true
+		}
 	}
 }


### PR DESCRIPTION
Composer 2.2.1+ requires plugins to be allowed